### PR TITLE
Fix when web-extension folder does not exist

### DIFF
--- a/yml/roles/share/tasks/main.yml
+++ b/yml/roles/share/tasks/main.yml
@@ -36,7 +36,7 @@
     src: "{{ hc_tmp }}/alfresco-web-extension.zip"
     dest: ../assets/{{ inventory_hostname }}/conf/
     flat: yes
-  when: webext_archive.state != 'absent'
+  when: webext_archive.failed == false
 
 - name: Fetch archived log files
   fetch:


### PR DESCRIPTION
web-extension is supposed to be in shared/alfresco but if it does not exist the archive module will fail and ansible will continue because ignore_errors is set to true

You will bump into:
"The conditional check 'webext_archive.state != 'absent'' failed. The error was: error while evaluating conditional (webext_archive.state != 'absent'): 'dict object' has no attribute 'state'