### PR TITLE
raw_input / input | pyhon2 / python3

### DIFF
--- a/hc-harvester
+++ b/hc-harvester
@@ -76,4 +76,7 @@ if __name__ == '__main__':
     passwd_ssh_user=''
     passwd_sudo=''
     execute_script=''
+# input / raw_input switch for python2.7 compatibilty
+    try: input = raw_input
+    except NameError: raw_input = input
     sys.exit(main(sys.argv))


### PR DESCRIPTION
raw_input isn't defined in Python3.x, whereas input wasn't behaving like raw_input in Python 2.x
this should make both input and raw_input work in Python 2.x/3.x like the raw_input from Python 2.x
see https://stackoverflow.com/questions/954834/how-do-i-use-raw-input-in-python-3