### PR TITLE
Db queries multiple files

### DIFF
--- a/yml/roles/alfresco-db-queries/tasks/main.yml
+++ b/yml/roles/alfresco-db-queries/tasks/main.yml
@@ -4,6 +4,15 @@
     state: directory
     path: "{{ hc_tmp }}"
 
+- name: Install oracle driver
+  command: mvn install:install-file -Dfile={{inventory_dir}}/alfresco-db-queries/lib/ojdbc6.jar -DgroupId=com.oracle -DartifactId=ojdbc6 -Dversion=11.2.0.3 -Dpackaging=jar
+  register: mvn_install_oracle
+
+# Compile only on the control node
+- name: Compile Alfresco DB Queries tool
+  local_action: command mvn -f {{inventory_dir}}/alfresco-db-queries/ clean compile install
+  register: mvn_result
+
 - name: Send Alfresco DB queries tool
   copy:
     src: "{{lookup('first_found', jarloc)}}"

--- a/yml/roles/alfresco-db-queries/tasks/main.yml
+++ b/yml/roles/alfresco-db-queries/tasks/main.yml
@@ -38,9 +38,15 @@
     url: http://localhost:{{ alfresco_db_queries_port }}/report
     timeout: "{{ db_queries_report_timeout }}"
 
+- name: Zip Alfresco-db-queries files
+  become: true
+  archive:
+    path: "{{ hc_tmp }}/acs-db-report*"
+    dest: "{{ hc_tmp }}/alfresco-db-reports.zip"
+    format: zip
+
 - name: Fetch DB queries report
   fetch:
-    src: "{{ hc_tmp }}/acs-db-report.csv"
+    src: "{{ hc_tmp }}/alfresco-db-reports.zip"
     dest: ../assets/
     flat: yes
-

--- a/yml/roles/alfresco-db-queries/templates/application.properties
+++ b/yml/roles/alfresco-db-queries/templates/application.properties
@@ -32,6 +32,12 @@ alf_auth_status={% if srv_info.json.data.version | regex_search('[0-9]+(\.[0-9]+
 largeFolderSize=1000
 largeTransactionSize=10000
 
+# While exporting generate one single file or one file per query. Valid values: true or false
+reportSplit=true
+
+# Export type. Valid values: csv or json or txt. Default txt
+reportExportType=csv
+
 # Generate a report on the same folder where the application is run
 reportFile=acs-db-report.csv
 


### PR DESCRIPTION
As the report will now generate multiple files, these files are now zipped.
Added some properties.

Alfresco-db-queries is now compiled directly via Ansible. The compilation happens only on control node.